### PR TITLE
Added conditional check for uuid in UsergridQuery to not wrap in single quotes

### DIFF
--- a/Source/UsergridExtensions.swift
+++ b/Source/UsergridExtensions.swift
@@ -16,3 +16,9 @@ internal extension NSDate {
         return Int(self.timeIntervalSince1970 * 1000)
     }
 }
+
+internal extension String {
+    func isUuid() -> Bool {
+        return (NSUUID(UUIDString: self) != nil) ? true : false
+    }
+}

--- a/Source/UsergridQuery.swift
+++ b/Source/UsergridQuery.swift
@@ -9,32 +9,32 @@
 import Foundation
 
 /**
-`UsergridQuery` is builder class used to construct filtered requests to Usergrid.
-
-`UsergridQuery` objects are then passed to `UsergridClient` or `Usergrid` methods which support `UsergridQuery` as a parameter are .GET(), .PUT(), and .DELETE().
-*/
+ `UsergridQuery` is builder class used to construct filtered requests to Usergrid.
+ 
+ `UsergridQuery` objects are then passed to `UsergridClient` or `Usergrid` methods which support `UsergridQuery` as a parameter are .GET(), .PUT(), and .DELETE().
+ */
 public class UsergridQuery : NSObject,NSCopying {
-
+    
     // MARK: - Initialization -
-
+    
     /**
     Desingated initializer for `UsergridQuery` objects.
-
+    
     - parameter collectionName: The collection name or `type` of entities you want to query.
-
+    
     - returns: A new instance of `UsergridQuery`.
     */
     public init(_ collectionName: String? = nil) {
         self.collectionName = collectionName
     }
-
+    
     // MARK: - NSCopying -
-
+    
     /**
     See the NSCopying protocol.
-
+    
     - parameter zone: Ignored
-
+    
     - returns: Returns a new instance that’s a copy of the receiver.
     */
     public func copyWithZone(zone: NSZone) -> AnyObject {
@@ -48,206 +48,206 @@ public class UsergridQuery : NSObject,NSCopying {
         queryCopy.cursor = self.cursor
         return queryCopy
     }
-
+    
     // MARK: - Building -
-
+    
     /**
     Constructs the string that should be appeneded to the end of the URL as a query.
-
+    
     - parameter autoURLEncode: Automatically encode the constructed string.
-
+    
     - returns: The constructed URL query sting.
     */
     public func build(autoURLEncode: Bool = true) -> String {
         return self.constructURLAppend(autoURLEncode)
     }
-
+    
     // MARK: - Builder Methods -
-
+    
     /**
     Contains. Query: where term contains 'val%'.
-
+    
     - parameter term:  The term.
     - parameter value: The value.
-
+    
     - returns: `Self`
     */
     public func containsString(term: String, value: String) -> Self { return self.containsWord(term, value: value) }
-
+    
     /**
-    Contains. Query: where term contains 'val%'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
-    public func containsWord(term: String, value: String) -> Self { return self.addRequirement(term + UsergridQuery.SPACE + UsergridQuery.CONTAINS + UsergridQuery.SPACE + UsergridQuery.APOSTROPHE + value + UsergridQuery.APOSTROPHE) }
-
+     Contains. Query: where term contains 'val%'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
+    public func containsWord(term: String, value: String) -> Self { return self.addRequirement(term + UsergridQuery.SPACE + UsergridQuery.CONTAINS + UsergridQuery.SPACE + ((value.isUuid()) ? UsergridQuery.EMPTY_STRING : UsergridQuery.APOSTROPHE) + value + ((value.isUuid()) ? UsergridQuery.EMPTY_STRING : UsergridQuery.APOSTROPHE)) }
+    
     /**
-    Sort ascending. Query:. order by term asc.
-
-    - parameter term: The term.
-
-    - returns: `Self`
-    */
+     Sort ascending. Query:. order by term asc.
+     
+     - parameter term: The term.
+     
+     - returns: `Self`
+     */
     public func ascending(term: String) -> Self { return self.asc(term) }
-
+    
     /**
-    Sort ascending. Query:. order by term asc.
-
-    - parameter term: The term.
-
-    - returns: `Self`
-    */
+     Sort ascending. Query:. order by term asc.
+     
+     - parameter term: The term.
+     
+     - returns: `Self`
+     */
     public func asc(term: String) -> Self { return self.sort(term, sortOrder: UsergridQuerySortOrder.Asc) }
-
+    
     /**
-    Sort descending. Query: order by term desc
-
-    - parameter term: The term.
-
-    - returns: `Self`
-    */
+     Sort descending. Query: order by term desc
+     
+     - parameter term: The term.
+     
+     - returns: `Self`
+     */
     public func descending(term: String) -> Self { return self.desc(term) }
-
+    
     /**
-    Sort descending. Query: order by term desc
-
-    - parameter term: The term.
-
-    - returns: `Self`
-    */
+     Sort descending. Query: order by term desc
+     
+     - parameter term: The term.
+     
+     - returns: `Self`
+     */
     public func desc(term: String) -> Self { return self.sort(term, sortOrder: UsergridQuerySortOrder.Desc) }
-
+    
     /**
-    Filter (or Equal-to). Query: where term = 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Filter (or Equal-to). Query: where term = 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func filter(term: String, value: AnyObject) -> Self { return self.eq(term, value: value) }
-
+    
     /**
-    Equal-to. Query: where term = 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Equal-to. Query: where term = 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func equals(term: String, value: AnyObject) -> Self { return self.eq(term, value: value) }
-
+    
     /**
-    Equal-to. Query: where term = 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Equal-to. Query: where term = 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func eq(term: String, value: AnyObject) -> Self { return self.addOperationRequirement(term, operation:.Equal, value: value) }
-
+    
     /**
-    Greater-than. Query: where term > 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Greater-than. Query: where term > 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func greaterThan(term: String, value: AnyObject) -> Self { return self.gt(term, value: value) }
-
+    
     /**
-    Greater-than. Query: where term > 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Greater-than. Query: where term > 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func gt(term: String, value: AnyObject) -> Self { return self.addOperationRequirement(term, operation:.GreaterThan, value: value) }
-
+    
     /**
-    Greater-than-or-equal-to. Query: where term >= 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Greater-than-or-equal-to. Query: where term >= 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func greaterThanOrEqual(term: String, value: AnyObject) -> Self { return self.gte(term, value: value) }
-
+    
     /**
-    Greater-than-or-equal-to. Query: where term >= 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Greater-than-or-equal-to. Query: where term >= 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func gte(term: String, value: AnyObject) -> Self { return self.addOperationRequirement(term, operation:.GreaterThanEqualTo, value: value) }
-
+    
     /**
-    Less-than. Query: where term < 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Less-than. Query: where term < 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func lessThan(term: String, value: AnyObject) -> Self { return self.lt(term, value: value) }
-
+    
     /**
-    Less-than. Query: where term < 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Less-than. Query: where term < 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func lt(term: String, value: AnyObject) -> Self { return self.addOperationRequirement(term, operation:.LessThan, value: value) }
-
+    
     /**
-    Less-than-or-equal-to. Query: where term <= 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Less-than-or-equal-to. Query: where term <= 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func lessThanOrEqual(term: String, value: AnyObject) -> Self { return self.lte(term, value: value) }
-
+    
     /**
-    Less-than-or-equal-to. Query: where term <= 'value'.
-
-    - parameter term:  The term.
-    - parameter value: The value.
-
-    - returns: `Self`
-    */
+     Less-than-or-equal-to. Query: where term <= 'value'.
+     
+     - parameter term:  The term.
+     - parameter value: The value.
+     
+     - returns: `Self`
+     */
     public func lte(term: String, value: AnyObject) -> Self { return self.addOperationRequirement(term, operation:.LessThanEqualTo, value: value) }
-
+    
     /**
-    Contains. Query: location within val of lat, long.
-
-    - parameter distance:  The distance from the latitude and longitude.
-    - parameter latitude:  The latitude.
-    - parameter longitude: The longitude.
-
-    - returns: `Self`
-    */
+     Contains. Query: location within val of lat, long.
+     
+     - parameter distance:  The distance from the latitude and longitude.
+     - parameter latitude:  The latitude.
+     - parameter longitude: The longitude.
+     
+     - returns: `Self`
+     */
     public func locationWithin(distance: Float, latitude: Float, longitude: Float) -> Self {
         return self.addRequirement(UsergridQuery.LOCATION + UsergridQuery.SPACE + UsergridQuery.WITHIN + UsergridQuery.SPACE + distance.description + UsergridQuery.SPACE + UsergridQuery.OF + UsergridQuery.SPACE + latitude.description + UsergridQuery.COMMA + longitude.description )
     }
-
+    
     /**
-    Joining operation to combine conditional queries.
-
-    - returns: `Self`
-    */
+     Joining operation to combine conditional queries.
+     
+     - returns: `Self`
+     */
     public func or() -> Self {
         if !self.requirementStrings.first!.isEmpty {
             self.requirementStrings.insert(UsergridQuery.OR, atIndex: 0)
@@ -255,10 +255,10 @@ public class UsergridQuery : NSObject,NSCopying {
         }
         return self
     }
-
+    
     /**
      Not operation for conditional queries.
-
+     
      - returns: `Self`
      */
     public func not() -> Self {
@@ -268,75 +268,75 @@ public class UsergridQuery : NSObject,NSCopying {
         }
         return self
     }
-
+    
     /**
-    Sort. Query: order by term `sortOrder`
-
-    - parameter term:       The term.
-    - parameter sortOrder:  The order.
-
-    - returns: `Self`
-    */
+     Sort. Query: order by term `sortOrder`
+     
+     - parameter term:       The term.
+     - parameter sortOrder:  The order.
+     
+     - returns: `Self`
+     */
     public func sort(term: String, sortOrder: UsergridQuerySortOrder) -> Self {
         self.orderClauses[term] = sortOrder
         return self
     }
-
+    
     /**
-    Sets the collection name.
-
-    - parameter collectionName: The new collection name.
-
-    - returns: `Self`
-    */
+     Sets the collection name.
+     
+     - parameter collectionName: The new collection name.
+     
+     - returns: `Self`
+     */
     public func collection(collectionName: String) -> Self {
         self.collectionName = collectionName
         return self
     }
-
+    
     /**
-    Sets the limit on the query.  Default limit is 10.
-
-    - parameter limit: The limit.
-
-    - returns: `Self`
-    */
+     Sets the limit on the query.  Default limit is 10.
+     
+     - parameter limit: The limit.
+     
+     - returns: `Self`
+     */
     public func limit(limit: Int) -> Self {
         self.limit = limit
         return self
     }
-
+    
     /**
-    Adds a preconstructed query string as a requirement onto the query.
-
-    - parameter value: The query string.
-
-    - returns: `Self`
-    */
+     Adds a preconstructed query string as a requirement onto the query.
+     
+     - parameter value: The query string.
+     
+     - returns: `Self`
+     */
     public func ql(value: String) -> Self {
         return self.addRequirement(value)
     }
-
+    
     /**
-    Sets the cursor of the query used internally by Usergrid's APIs.
-
-    - parameter value: The cursor.
-
-    - returns: `Self`
-    */
+     Sets the cursor of the query used internally by Usergrid's APIs.
+     
+     - parameter value: The cursor.
+     
+     - returns: `Self`
+     */
     public func cursor(value: String?) -> Self {
         self.cursor = value
         return self
     }
-
+    
     /**
-    Adds a URL term that will be added next to the query string when constructing the URL append.
-
-    - parameter term:        The term.
-    - parameter equalsValue: The value.
-
-    - returns: `Self`
-    */
+     Adds a URL term that will be added next to the query string when constructing the URL append.
+     
+     - parameter term:        The term.
+     - parameter equalsValue: The value.
+     
+     - returns: `Self`
+     */
     public func urlTerm(term: String, equalsValue: String) -> Self {
         if (term as NSString).isEqualToString(UsergridQuery.QL) {
             self.ql(equalsValue)
@@ -345,33 +345,33 @@ public class UsergridQuery : NSObject,NSCopying {
         }
         return self
     }
-
+    
     /**
-    Adds a string requirement to the query.
-
-    - parameter term:        The term.
-    - parameter operation:   The operation.
-    - parameter stringValue: The string value.
-
-    - returns: `Self`
-    */
+     Adds a string requirement to the query.
+     
+     - parameter term:        The term.
+     - parameter operation:   The operation.
+     - parameter stringValue: The string value.
+     
+     - returns: `Self`
+     */
     public func addOperationRequirement(term: String, operation: UsergridQueryOperator, stringValue: String) -> Self {
         return self.addOperationRequirement(term,operation:operation,value:stringValue)
     }
-
+    
     /**
-    Adds a integer requirement to the query.
-
-    - parameter term:      The term.
-    - parameter operation: The operation.
-    - parameter intValue:  The integer value.
-
-    - returns: `Self`
-    */
+     Adds a integer requirement to the query.
+     
+     - parameter term:      The term.
+     - parameter operation: The operation.
+     - parameter intValue:  The integer value.
+     
+     - returns: `Self`
+     */
     public func addOperationRequirement(term: String, operation: UsergridQueryOperator, intValue: Int) -> Self {
         return self.addOperationRequirement(term,operation:operation,value:intValue)
     }
-
+    
     private func addRequirement(requirement: String) -> Self {
         var requirementString: String = self.requirementStrings.removeAtIndex(0)
         if !requirementString.isEmpty {
@@ -381,15 +381,15 @@ public class UsergridQuery : NSObject,NSCopying {
         self.requirementStrings.insert(requirementString, atIndex: 0)
         return self
     }
-
+    
     private func addOperationRequirement(term: String, operation: UsergridQueryOperator, value: AnyObject) -> Self {
         if value is String {
-            return self.addRequirement(term + UsergridQuery.SPACE + operation.stringValue + UsergridQuery.SPACE + UsergridQuery.APOSTROPHE + value.description + UsergridQuery.APOSTROPHE )
+            return self.addRequirement(term + UsergridQuery.SPACE + operation.stringValue + UsergridQuery.SPACE + ((value.description.isUuid()) ? UsergridQuery.EMPTY_STRING : UsergridQuery.APOSTROPHE) + value.description + ((value.description.isUuid()) ? UsergridQuery.EMPTY_STRING : UsergridQuery.APOSTROPHE) )
         } else {
             return self.addRequirement(term + UsergridQuery.SPACE + operation.stringValue + UsergridQuery.SPACE + value.description)
         }
     }
-
+    
     private func constructOrderByString() -> String {
         var orderByString = UsergridQuery.EMPTY_STRING
         if !self.orderClauses.isEmpty {
@@ -409,29 +409,29 @@ public class UsergridQuery : NSObject,NSCopying {
         }
         return orderByString
     }
-
+    
     private func constructURLTermsString() -> String {
         return (self.urlTerms as NSArray).componentsJoinedByString(UsergridQuery.AMPERSAND)
     }
-
+    
     private func constructRequirementString() -> String {
         var requirementsString = UsergridQuery.EMPTY_STRING
         var requirementStrings = self.requirementStrings
-
+        
         // If the first requirement is empty lets remove it.
         if let firstRequirement = requirementStrings.first where firstRequirement.isEmpty {
             requirementStrings.removeFirst()
         }
-
+        
         // If the first requirement now is a conditional separator then we should remove it so its not placed at the end of the constructed string.
         if let firstRequirement = requirementStrings.first where firstRequirement == UsergridQuery.OR || firstRequirement == UsergridQuery.NOT {
             requirementStrings.removeFirst()
         }
-
+        
         requirementsString = (requirementStrings.reverse() as NSArray).componentsJoinedByString(UsergridQuery.SPACE)
         return requirementsString
     }
-
+    
     private func constructURLAppend(autoURLEncode: Bool = true) -> String {
         var urlAppend = UsergridQuery.EMPTY_STRING
         if self.limit != UsergridQuery.LIMIT_DEFAULT {
@@ -450,7 +450,7 @@ public class UsergridQuery : NSObject,NSCopying {
             }
             urlAppend += "\(UsergridQuery.CURSOR)=\(cursorString)"
         }
-
+        
         var requirementsString = self.constructRequirementString()
         let orderByString = self.constructOrderByString()
         if !orderByString.isEmpty {
@@ -467,21 +467,21 @@ public class UsergridQuery : NSObject,NSCopying {
             }
             urlAppend += "\(UsergridQuery.QL)=\(requirementsString)"
         }
-
+        
         if !urlAppend.isEmpty {
             urlAppend = "\(UsergridQuery.QUESTION_MARK)\(urlAppend)"
         }
         return urlAppend
     }
-
+    
     private(set) var collectionName: String? = nil
     private(set) var cursor: String? = nil
     private(set) var limit: Int = UsergridQuery.LIMIT_DEFAULT
-
+    
     private(set) var requirementStrings: [String] = [UsergridQuery.EMPTY_STRING]
     private(set) var orderClauses: [String:UsergridQuerySortOrder] = [:]
     private(set) var urlTerms: [String] = []
-
+    
     private static let LIMIT_DEFAULT = 10
     private static let AMPERSAND = "&"
     private static let AND = "and"
@@ -501,7 +501,7 @@ public class UsergridQuery : NSObject,NSCopying {
     private static let QUESTION_MARK = "?"
     private static let SPACE = " "
     private static let WITHIN = "within"
-
+    
     internal static let ASC = "asc"
     internal static let DESC = "desc"
     internal static let EQUAL = "="


### PR DESCRIPTION
And not sure why Xcode decided to fiddle with the whitespace, but the actual code changes are minimal.

Essentially this checks to see if the string is a uuid when building a UsergridQuery; if it's not, then the text gets surrounded in ''. If it is, the '' are omitted.